### PR TITLE
detect Picture storage on SD card and sync it

### DIFF
--- a/src/daemon/filesystem.cpp
+++ b/src/daemon/filesystem.cpp
@@ -89,7 +89,8 @@ void Filesystem::rescan()
             QDir(pictureDir).exists()){
 
             qDebug() << "Found photo storage:" << pictureDir;
-            pictureLocations << WatchedLocation{pictureDir, "SD Card" + (sdCardNum == 0 ? QString(): " " + QString::number(sdCardNum))};
+            QString locationName = "SD Card" + (sdCardNum == 0 ? QString(): " " + QString::number(sdCardNum));
+            pictureLocations << WatchedLocation{pictureDir, locationName};
             sdCardNum++;
         }
     }

--- a/src/daemon/filesystem.cpp
+++ b/src/daemon/filesystem.cpp
@@ -4,9 +4,12 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QMutexLocker>
+#include <QStandardPaths>
+#include <QStorageInfo>
+#include <QSet>
 
-Filesystem::Filesystem(AccountBase* account, const QString& localPath) :
-    m_account(account), m_localPath(localPath)
+Filesystem::Filesystem(AccountBase* account) :
+    m_account(account)
 {
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &Filesystem::prepareScan);
 }
@@ -21,7 +24,7 @@ void Filesystem::prepareScan(QString dirPath)
     }
 }
 
-void Filesystem::scan(QString dirPath, bool recursive)
+void Filesystem::scan(WatchedLocation location, QString dirPath, bool recursive)
 {
     if (this->m_inhibit)
         return;
@@ -32,6 +35,7 @@ void Filesystem::scan(QString dirPath, bool recursive)
 
     if (!m_watcher.directories().contains(dirPath)) {
         m_watcher.addPath(dirPath);
+        m_watcherLocations[dirPath]=location;
     }
 
     const QFileInfoList entries = dir.entryInfoList(QDir::Dirs |
@@ -42,7 +46,7 @@ void Filesystem::scan(QString dirPath, bool recursive)
     for (const QFileInfo &entry : entries) {
         QString path = entry.absoluteFilePath();
         if (entry.isDir() && recursive) {
-            scan(path, recursive);
+            scan(location, path, recursive);
             continue;
         }
 
@@ -54,22 +58,51 @@ void Filesystem::scan(QString dirPath, bool recursive)
         }
 
         if(!entry.isDir()) {
-            emit fileFound(path);
+            emit fileFound(location.localDir, location.name, path);
             m_existingFiles.insert(path);
         } else if (entry.isDir() && !m_watcher.directories().contains(path)){
             m_watcher.addPath(path);
+            m_watcherLocations[dirPath]=location;
         }
     }
 }
 
 void Filesystem::rescan()
 {
-    QFileInfo dirInfo(m_localPath);
-    if (!dirInfo.exists() || !dirInfo.isDir()) {
-        qWarning() << "invalid path for watching" << dirInfo.absolutePath();
+    QList<WatchedLocation> pictureLocations;
+
+    QString internalPictureStorage = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
+    if (QFileInfo(internalPictureStorage).exists()) {
+        pictureLocations << WatchedLocation{internalPictureStorage, "Internal"};
     }
 
-    scan(dirInfo.absoluteFilePath(), true);
+    // iterate through mount volumes and try to find external drives with Pictures
+    // TODO: use card UUID and some kind of persistent configuration to proper support of multiple SD cards
+    int sdCardNum = 0;
+    for (const QStorageInfo &storage : QStorageInfo::mountedVolumes()){
+        QString mountPoint = storage.rootPath();
+        QString pictureDir = mountPoint + QDir::separator() + "Pictures";
+
+        if (storage.isValid() &&
+            storage.isReady() &&
+            mountPoint.startsWith("/run/media/") && // Sailfish OS specific mount point base for SD cards!
+            QDir(pictureDir).exists()){
+
+            qDebug() << "Found photo storage:" << pictureDir;
+            pictureLocations << WatchedLocation{pictureDir, "SD Card" + (sdCardNum == 0 ? QString(): " " + QString::number(sdCardNum))};
+            sdCardNum++;
+        }
+    }
+
+    for (const WatchedLocation &location: pictureLocations) {
+        QFileInfo dirInfo(location.localDir);
+        if (!dirInfo.exists() || !dirInfo.isDir()) {
+            qWarning() << "invalid path for watching" << dirInfo.absolutePath();
+        }
+
+        emit locationFound(location.localDir, location.name);
+        scan(location, dirInfo.absoluteFilePath(), true);
+    }
 }
 
 void Filesystem::inhibitScan(bool inhibit)
@@ -85,6 +118,7 @@ void Filesystem::triggerRescan()
         return;
 
     if (!m_watcher.directories().isEmpty()) {
+        m_watcherLocations.clear();
         m_watcher.removePaths(m_watcher.directories());
     }
     m_existingFiles.clear();
@@ -117,7 +151,11 @@ void Filesystem::insertDelay(QString path)
             if(m_delayers.at(i).path == path)
                 m_delayers.removeAt(i);
         }
-        scan(path);
+        if (m_watcherLocations.contains(path)) {
+            scan(m_watcherLocations[path], path);
+        }else{
+            qWarning() << "Can't found location for path" << path;
+        }
     });
     delay.timer->start();
     connect(delay.timer, &QTimer::timeout, delay.timer, &QObject::deleteLater);

--- a/src/daemon/filesystem.h
+++ b/src/daemon/filesystem.h
@@ -5,6 +5,7 @@
 #include <QFileSystemWatcher>
 #include <QMutex>
 #include <QSet>
+#include <QMap>
 #include <QTimer>
 #include <settings/nextcloudsettingsbase.h>
 
@@ -17,19 +18,24 @@ class Filesystem : public QObject
         QTimer *timer = Q_NULLPTR;
     };
 
+    struct WatchedLocation {
+        QString localDir;
+        QString name;
+    };
+
 public:
-    Filesystem(AccountBase* account = Q_NULLPTR,
-               const QString& localPath = QStringLiteral(""));
+    Filesystem(AccountBase* account = Q_NULLPTR);
 
 signals:
-    void fileFound(QString fullPath);
+    void fileFound(QString locationDir, QString locationName, QString fullPath);
+    void locationFound(QString locationDir, QString locationName);
 
 public slots:
     void inhibitScan(bool inhibit);
     void triggerRescan();
 
 private slots:
-    void scan(QString dirPath, bool recursive = false);
+    void scan(WatchedLocation location, QString dirPath, bool recursive = false);
     void prepareScan(QString dirPath);
 
 private:
@@ -37,7 +43,7 @@ private:
 
     AccountBase* m_account;
     QFileSystemWatcher m_watcher;
-    const QString m_localPath;
+    QMap<QString, WatchedLocation> m_watcherLocations;
     QSet<QString> m_existingFiles;
     bool m_inhibit = false;
 

--- a/src/daemon/uploader.cpp
+++ b/src/daemon/uploader.cpp
@@ -42,11 +42,6 @@ void Uploader::triggerSync(const QString &localPath, const QString &remoteSubdir
         return;
     }
 
-    if (this->m_webDavCommandQueue->queue().length() > 64) {
-        qWarning() << "Skip sync, queue is busy";
-        return;
-    }
-
     QString remoteDir = this->m_targetDirectory + '/' + remoteSubdir + '/';
     qDebug() << "Trigger sync" << localPath << "to" << remoteDir;
 

--- a/src/daemon/uploader.cpp
+++ b/src/daemon/uploader.cpp
@@ -1,14 +1,15 @@
 #include "uploader.h"
 
 #include <commands/sync/ncsynccommandunit.h>
+#include <commands/webdav/mkdavdircommandentity.h>
+
+#include <QDir>
 
 Uploader::Uploader(QObject *parent,
-                   const QString& localPath,
                    const QString& targetDirectory,
                    NetworkMonitor* networkMonitor,
                    AccountBase* settings) :
     QObject(parent),
-    m_localPath(localPath),
     m_targetDirectory(targetDirectory),
     m_networkMonitor(networkMonitor),
     m_settings(settings),
@@ -19,7 +20,7 @@ Uploader::Uploader(QObject *parent,
                      this, &Uploader::runningChanged);
 }
 
-void Uploader::triggerSync()
+void Uploader::triggerSync(const QString &localPath, const QString &remoteSubdir)
 {
     if (!(this->m_webDavCommandQueue && this->m_settings && this->m_networkMonitor)) {
         qCritical() << "Invalid object existance (webDavQueue, settings, netMonitor), "
@@ -35,14 +36,35 @@ void Uploader::triggerSync()
         return;
     }
 
-    if (this->m_webDavCommandQueue->queue().length() > 0)
+    // detect if sync for "localPath" is in the queue already
+    if (m_syncingPaths.contains(localPath)){
+        qWarning() << "Syncing already:" << localPath;
         return;
+    }
+
+    if (this->m_webDavCommandQueue->queue().length() > 64) {
+        qWarning() << "Skip sync, queue is busy";
+        return;
+    }
+
+    QString remoteDir = this->m_targetDirectory + '/' + remoteSubdir + '/';
+    qDebug() << "Trigger sync" << localPath << "to" << remoteDir;
+
+    // create parent directory
+    // NcSyncCommandUnit dont creating remote directories recursively
+    // TODO: do it properly
+    this->m_webDavCommandQueue->makeDirectoryRequest(this->m_targetDirectory, true);
 
     NcSyncCommandUnit* syncDirectoriesUnit =
             new NcSyncCommandUnit(this->m_webDavCommandQueue,
                                   this->m_webDavCommandQueue,
-                                  this->m_localPath,
-                                  this->m_targetDirectory);
+                                  localPath,
+                                  remoteDir);
+
+    m_syncingPaths << localPath;
+
+    connect(syncDirectoriesUnit, &CommandEntity::aborted, [localPath, this](){ m_syncingPaths.remove(localPath); });
+    connect(syncDirectoriesUnit, &CommandEntity::done,    [localPath, this](){ m_syncingPaths.remove(localPath); });
 
     this->m_webDavCommandQueue->enqueue((CommandEntity*)syncDirectoriesUnit);
 }

--- a/src/daemon/uploader.h
+++ b/src/daemon/uploader.h
@@ -11,7 +11,6 @@ class Uploader : public QObject
     Q_OBJECT
 public:
     explicit Uploader(QObject *parent = Q_NULLPTR,
-                      const QString& localPath = QStringLiteral(""),
                       const QString& targetDirectory = QStringLiteral(""),
                       NetworkMonitor* networkMonitor = Q_NULLPTR,
                       AccountBase* settings = Q_NULLPTR);
@@ -20,15 +19,15 @@ public:
     bool shouldSync();
 
 public slots:
-    void triggerSync();
+    void triggerSync(const QString &localPath, const QString &remoteSubdir);
     void stopSync();
 
 private:
-    const QString m_localPath;
     const QString m_targetDirectory;
     NetworkMonitor* m_networkMonitor = Q_NULLPTR;
     AccountBase* m_settings = Q_NULLPTR;
     WebDavCommandQueue* m_webDavCommandQueue = Q_NULLPTR;
+    QSet<QString> m_syncingPaths;
 
 signals:
     void runningChanged();


### PR DESCRIPTION
Hi. 

Sync daemon for GhostCloud is great, but I was missing support for SD card. And from openrepos comments, I am not alone. For that reason, I prepare support for multiple photo locations. 

 - `Filesystem::rescan` lookup all picture locations
 - location dir and name is added to `fileFound` signal
 - `locationFound` signal was introduced
 - `Uploader` now supports subdirectories and prevents sync enqueue for already processing location