### PR TITLE
Nephros' update for 4.4, rebased

### DIFF
--- a/rpm/harbour-owncloud.spec
+++ b/rpm/harbour-owncloud.spec
@@ -35,6 +35,8 @@ BuildRequires:  pkgconfig(Qt5Svg)
 BuildRequires:  pkgconfig(nemotransferengine-qt5)
 BuildRequires:  desktop-file-utils
 
+BuildRequires:  pkgconfig(systemd)
+
 %description
 Unofficial NextCloud/ownCloud client for SailfishOS
 
@@ -91,10 +93,10 @@ desktop-file-install --delete-original       \
 %{_bindir}/%{name}-daemon
 %{_bindir}/%{name}-permission-agent
 %defattr(-,root,root,-)
-/usr/lib/systemd/user/%{name}-daemon.service
-/usr/lib/systemd/user/%{name}-permission-agent.service
-/usr/lib/systemd/user/user-session.target.wants/%{name}-daemon.service
-/usr/lib/systemd/user/user-session.target.wants/%{name}-permission-agent.service
+%{_userunitdir}/%{name}-daemon.service
+%{_userunitdir}/%{name}-permission-agent.service
+%{_userunitdir}/user-session.target.wants/%{name}-daemon.service
+%{_userunitdir}/user-session.target.wants/%{name}-permission-agent.service
 %{_datadir}/nemo-transferengine/plugins/
 %{_libdir}/nemo-transferengine/plugins/libghostcloudshareplugin.so
 %{_libdir}/qt5/qml/com/github/beidl/harbourowncloud/libharbourowncloudqmlplugin.so

--- a/rpm/harbour-owncloud.spec
+++ b/rpm/harbour-owncloud.spec
@@ -42,7 +42,8 @@ Unofficial NextCloud/ownCloud client for SailfishOS
 
 %package daemon
 Summary:   NextCloud/ownCloud background task for automatic camera backups
-Requires:  harbour-owncloud = %{version}
+#Requires:  harbour-owncloud = %{version}
+Requires:  harbour-owncloud
 
 %description daemon
 Nextcloud/ownCloud background task for automatic camera backups

--- a/rpm/harbour-owncloud.spec
+++ b/rpm/harbour-owncloud.spec
@@ -57,9 +57,9 @@ Nextcloud/ownCloud background task for automatic camera backups
 # >> build pre
 # << build pre
 
-%qtc_qmake5
+%qtc_qmake5 CONFIG+="sailfish_build nosharing"
 
-%qtc_make %{?_smp_mflags} CONFIG+=sailfish_build
+%qtc_make %{?_smp_mflags} CONFIG+="sailfish_build nosharing"
 
 # >> build post
 # << build post
@@ -97,14 +97,14 @@ desktop-file-install --delete-original       \
 %{_userunitdir}/%{name}-permission-agent.service
 %{_userunitdir}/user-session.target.wants/%{name}-daemon.service
 %{_userunitdir}/user-session.target.wants/%{name}-permission-agent.service
-%{_datadir}/nemo-transferengine/plugins/
-%{_libdir}/nemo-transferengine/plugins/libghostcloudshareplugin.so
+#%%{_datadir}/nemo-transferengine/plugins/
+#%%{_libdir}/nemo-transferengine/plugins/libghostcloudshareplugin.so
 %{_libdir}/qt5/qml/com/github/beidl/harbourowncloud/libharbourowncloudqmlplugin.so
 %{_libdir}/qt5/qml/com/github/beidl/harbourowncloud/qmldir
-%{_datadir}/themes/sailfish-default/meegotouch/z1.0/icons/icon-m-share-%{name}.png
-%{_datadir}/themes/sailfish-default/meegotouch/z1.25/icons/icon-m-share-%{name}.png
-%{_datadir}/themes/sailfish-default/meegotouch/z1.5-large/icons/icon-m-share-%{name}.png
-%{_datadir}/themes/sailfish-default/meegotouch/z1.75/icons/icon-m-share-%{name}.png
+#%%{_datadir}/themes/sailfish-default/meegotouch/z1.0/icons/icon-m-share-%{name}.png
+#%%{_datadir}/themes/sailfish-default/meegotouch/z1.25/icons/icon-m-share-%{name}.png
+#%%{_datadir}/themes/sailfish-default/meegotouch/z1.5-large/icons/icon-m-share-%{name}.png
+#%%{_datadir}/themes/sailfish-default/meegotouch/z1.75/icons/icon-m-share-%{name}.png
 
 # >> files
 # << files

--- a/rpm/harbour-owncloud.spec
+++ b/rpm/harbour-owncloud.spec
@@ -28,6 +28,10 @@ BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(Qt5Xml)
+BuildRequires:  pkgconfig(Qt5Multimedia)
+BuildRequires:  pkgconfig(Qt5Svg)
+
 BuildRequires:  pkgconfig(nemotransferengine-qt5)
 BuildRequires:  desktop-file-utils
 

--- a/src/sharing/ghostcloudplugininfo.h
+++ b/src/sharing/ghostcloudplugininfo.h
@@ -1,7 +1,7 @@
 #ifndef NEXTCLOUDPLUGININFO_H
 #define NEXTCLOUDPLUGININFO_H
 
-#include <TransferEngine-qt5/transferplugininfo.h>
+#include <transferplugininfo.h>
 #include <QList>
 
 class GhostCloudPluginInfo : public TransferPluginInfo

--- a/src/sharing/ghostcloudshareplugin.h
+++ b/src/sharing/ghostcloudshareplugin.h
@@ -1,7 +1,7 @@
 #ifndef NEXTCLOUDSHAREPLUGIN_H
 #define NEXTCLOUDSHAREPLUGIN_H
 
-#include <TransferEngine-qt5/transferplugininterface.h>
+#include <transferplugininterface.h>
 #include "ghostcloudconsts.h"
 #include <QObject>
 


### PR DESCRIPTION
As lame as it is to not have built the code, because of lacking spare time and not even having an SDK set up, there is evidence this could work:

  * https://forum.sailfishos.org/t/ghostcloud-additionals-on-aarch64-devices/11638/3
  * https://github.com/nephros/harbour-owncloud/tree/update-4.4

I rebased that onto the latest master, and may even get around to building it, though that might take forever.

If you wouldn't mind giving it a shot and see if it can be merged, that would be great.
