### PR TITLE
webdav uniqueId property is unique just per URI resource

### DIFF
--- a/src/common/src/commands/sync/ncdirtreecommandunit.cpp
+++ b/src/common/src/commands/sync/ncdirtreecommandunit.cpp
@@ -110,7 +110,8 @@ void NcDirTreeCommandUnit::expand(CommandEntity* previousCommandEntity)
         const QVariantMap entry = tmpEntry.toMap();
         const bool entryIsDirectory = entry.value(QStringLiteral("isDirectory")).toBool();
         const QString entryName = entry.value(QStringLiteral("name")).toString();
-        const QString uniqueId = entry.value(QStringLiteral("uniqueId")).toString();
+        // we cannot assume that uniqueId is unique for different paths, ETag uniqueness is only required per-URI resource, not globally.
+        const QString uniqueId = entry.value(QStringLiteral("path")).toString() + ":" + entry.value(QStringLiteral("uniqueId")).toString();
 
         qDebug() << "entryName:" << entryName;
 
@@ -119,8 +120,10 @@ void NcDirTreeCommandUnit::expand(CommandEntity* previousCommandEntity)
                     this->m_currentNode->containsDirWithUniqueId(uniqueId) :
                     this->m_currentNode->containsFileWithUniqueId(uniqueId);
 
-        if (uniqueIdsMatch)
+        if (uniqueIdsMatch) {
+            qInfo() << "Skipping entry as unique ID already exists:" << entryName << uniqueId;
             continue;
+        }
 
         if (!entryIsDirectory) {
             // Add to the list of files and


### PR DESCRIPTION
As seen on real NextCloud instance, multiple directories created in short time period may have the same getetag property.

It leads to the filtering of some directories out when constructing cache of existing directories and error when attempting to create alredy-existing directory again.
Probably same issue as seen here:
https://github.com/fredldotme/harbour-owncloud/issues/76

GPT-5.2 model says:

   - ETag uniqueness is only required per-URI resource, not globally. In HTTP, an ETag is a validator for that resource representation. Two different URLs can legally return the same ETag value.
   - Some servers use weak/cheap ETags. For collections (directories), servers often generate ETags from:
      - a timestamp with low resolution,
      - a revision counter that can coincide, - a hash that’s not namespaced by path, - or even a constant/placeholder (yes, some do this for directories).

Considerint these, uniqueId should be constructed by the combination of the path and ETag.